### PR TITLE
Adding UED timing mode

### DIFF
--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -1,5 +1,8 @@
 Release Notes for rogueRegister EPICS module
 
+R2.6.0: 2026-05-26 Kaushik Malapati
+    Added SeqUEDTiming
+
 R2.5.0: 2026-03-09 Vincent Esposito
     Fixed issue with the wave8 register mapping
 

--- a/rogueApp/Db/PgpCannedSequences.db
+++ b/rogueApp/Db/PgpCannedSequences.db
@@ -174,6 +174,46 @@ record( seq, "$(PGP):SeqXpmMiniTiming" )
 	info( autosaveFields, "DESC" )
 }
 
+# Select UED Timing
+record( seq, "$(PGP):SeqUEDTiming" )
+{
+	field( DESC, "Select UED Timing" )
+
+	#      First Disable triggers
+	field( DLY0, "0" ) field( DOL0, "0" ) field( LNK0, "$(PGP):ChAll:EvrV2:EnableReg  PP NMS" )
+
+	# Disable MiniTpg and set ModeSelEn to UseModeSel
+	field( DLY1, "0" ) field( DOL1, "0" ) field( LNK1, "$(PGP):Timing:UseMiniTpg    PP NMS" )
+	field( DLY2, "0" ) field( DOL2, "1" ) field( LNK2, "$(PGP):Timing:ModeSelEn     PP NMS" )
+
+	# Assert RxPllReset for 1 sec
+	field( DLY3, "0" ) field( DOL3, "1" ) field( LNK3, "$(PGP):Timing:RxPllReset    PP NMS" )
+	field( DLY4, "1" ) field( DOL4, "0" ) field( LNK4, "$(PGP):Timing:RxPllReset    PP NMS" )
+
+	# Select LCLS-I Clock for UED
+	field( DLY5, "0" ) field( DOL5, "0" ) field( LNK5, "$(PGP):Timing:ClkSel        PP NMS" )
+	field( DLY6, "0" ) field( DOL6, "1" ) field( LNK6, "$(PGP):Timing:ModeSel       PP NMS" )
+
+	# Assert C_RxReset for 1 sec
+	field( DLY7, "0" ) field( DOL7, "1" ) field( LNK7, "$(PGP):Timing:C_RxReset     PP NMS" )
+	field( DLY8, "1" ) field( DOL8, "0" ) field( LNK8, "$(PGP):Timing:C_RxReset     PP NMS" )
+
+	# Reset the latching register
+	field( DLY9, ".1") field( DOL9, "0" ) field( LNK9, "$(PGP):Timing:RxDown        PP NMS" )
+
+	# Set EventBuilder Bypass to mask out XPM Timing Message for UED timing
+	field( DLYA, "0" ) field( DOLA, "4" ) field( LNKA, "$(PGP):ChAll:EventBuilder:BypassXPM  PP NMS" )
+
+	# Set RateType to FixedRates for LCLS2 timing rates
+	field( DLYB, "0" ) field( DOLB, "0" ) field( LNKB, "$(PGP):ChAll:EvrV2:RateTypeControlWord PP NMS" )
+
+	# Set RateSel for each channel to that channel's LCLS2 timing rate
+	field( DLYC, "0" ) field( DOLC, "1" ) field( LNKC, "$(PGP):ChAll:Lcls2:RateSel.PROC  PP NMS" )
+
+	info( autosaveFields, "DESC" )
+	#     info( autosaveFields, "DESC DOL1 DLY1 DOL2 DLY2 DOL3 DLY3 DOL4 DLY4 DOL5 DLY5 DOL6 DLY6 DOL7 DLY7 DOL8 DLY8 DOL9 DLY9 DOLA DLYA" )
+}
+
 record( dfanout, "$(PGP):ChAll:EventBuilder:BypassXPM" )
 {
 	field( DESC, "Bypass XPM DAQ msgs in EventBuilder" )


### PR DESCRIPTION
UED uses the LCLS1 clock, but LCLS2 for the mode. This pr adds a SeqUEDTiming record, similar to SeqLcls1Timing and SeqLcls2Timing, but with ModeSelEn=1, ClkSel=0, and ModelSel=1. Tested and working in UED; tprTrigger has an analogous mode - https://github.com/slac-epics/tprTrigger/blob/2a78a8cdc98474296d751066d146e0c10ed4b7c1/tprTriggerApp/src/tprTriggerAsynDriver.cpp#L1182-L1192. I updated RELEASE_NOTES with the presumption that a new tag, R2.6.0, would be created after this is merged